### PR TITLE
Fixes Executing Callbacks Multiple Times

### DIFF
--- a/breakpoints.js
+++ b/breakpoints.js
@@ -67,8 +67,9 @@ Reusables.Breakpoints = (function ($) {
       var $element = $(element);
       var width = $element.outerWidth();
       var matchNow = breakpoint.min <= width && width < breakpoint.max;
-      var matchBefore = $element.hasClass(breakpoint.name);
+      var matchBefore = $element.data(breakpoint.name) || false;
       var change = matchNow !== matchBefore;
+      $element.data(breakpoint.name, matchNow);
       var entering = change && matchNow;
       var exiting = change && !matchNow;
       if (entering) {


### PR DESCRIPTION
Enter and exit callbacks were being executed multiple times during window 
resize. I think this is because there is a delay before the class is actually
added to the element and that is what we are using to determine if the
breakpoint matches. Instead, we use breakpoint name as a data attribute on the
element and set it true or false.
