### PR TITLE
Enter Callback Queue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "breakpoints-js",
   "main": "breakpoints.js",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "homepage": "https://github.com/reusables/breakpoints.js",
   "authors": [
     "Joshua Stoutenburg <jehoshua02@gmail.com>"

--- a/breakpoints-js.jquery.json
+++ b/breakpoints-js.jquery.json
@@ -1,6 +1,6 @@
 {
     "name": "breakpoints-js",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "title": "Breakpoints.js",
     "author": {
         "name": "Joshua Stoutenburg",

--- a/breakpoints.js
+++ b/breakpoints.js
@@ -10,7 +10,7 @@ Reusables.Breakpoints = (function ($) {
 
     this.process = function () {
       while (callbacks.length !== 0) {
-        (callbacks.unshift())();
+        (callbacks.pop())();
       }
     };
   };

--- a/breakpoints.js
+++ b/breakpoints.js
@@ -1,6 +1,22 @@
 var Reusables = Reusables || {};
 Reusables.Breakpoints = (function ($) {
 
+  var Queue = function () {
+    var callbacks = [];
+
+    this.push = function (callback) {
+      callbacks.push(callback);
+    };
+
+    this.process = function () {
+      while (callbacks.length !== 0) {
+        (callbacks.unshift())();
+      }
+    };
+  };
+
+  var enterQueue = new Queue();
+
   var Breakpoint = function ($elements, range, options) {
     this.$elements = $elements;
     this.range = range;
@@ -74,8 +90,10 @@ Reusables.Breakpoints = (function ($) {
       var entering = change && matchNow;
       var exiting = change && !matchNow;
       if (entering) {
-        $element.addClass(breakpoint.name);
-        breakpoint.enter($element);
+        enterQueue.push(function () {
+          $element.addClass(breakpoint.name);
+          breakpoint.enter($element);
+        });
       } else if (exiting) {
         $element.removeClass(breakpoint.name);
         breakpoint.exit($element);
@@ -110,6 +128,7 @@ Reusables.Breakpoints = (function ($) {
       for (var i = 0; i < length; i++) {
         breakpoints[i].evaluate();
       }
+      enterQueue.process();
     };
 
   })();


### PR DESCRIPTION
Instead of adding class name and executing enter callback, these actions are
queued and processed after all breakpoints are evaluated so that they execute
after exit callbacks.
